### PR TITLE
Add seed argument for reproducible rarefaction sampling

### DIFF
--- a/R/calculate_spectral_metrics.R
+++ b/R/calculate_spectral_metrics.R
@@ -8,6 +8,9 @@
 #' @param rarefaction Logical; if TRUE, applies a rarefaction step that increases processing time.
 #' @param min_points Integer; minimum number of pixels per `aoi` to standardize uneven pixel numbers across sites (used if `rarefaction = TRUE`).
 #' @param n Integer; number of subset permutations if `rarefaction = TRUE`.
+#' @param seed Integer or NULL; if provided, `set.seed(seed)` is called once at the
+#'   start of the function so the rarefaction sampling is reproducible. Default
+#'   `NULL` preserves the prior unseeded behaviour.
 #' @return A dataframe containing spectral metrics for each `aoi` within each site/raster.
 #' @aliases calculate_cv calculate_sv calculate_chv_nopca calculate_spectral_metrics
 #' @export
@@ -30,7 +33,10 @@ calculate_cv <- function(pixel_values_df,
                          wavelengths,
                          rarefaction = FALSE,
                          min_points = NULL,
-                         n = NULL) {
+                         n = NULL,
+                         seed = NULL) {
+
+  if (!is.null(seed)) set.seed(seed)
 
   # convert to a data.table for efficiency
   data.table::setDT(pixel_values_df)
@@ -110,7 +116,10 @@ calculate_chv_nopca <- function(df,
                                 wavelengths,
                                 rarefaction = FALSE,
                                 min_points = NULL,
-                                n = NULL) {
+                                n = NULL,
+                                seed = NULL) {
+
+  if (!is.null(seed)) set.seed(seed)
 
   # convert to data.table for better performance
   setDT(df)
@@ -157,7 +166,8 @@ calculate_spectral_metrics <- function(pixel_values_df,
                                        wavelengths,
                                        rarefaction = FALSE,
                                        min_points = NULL,
-                                       n = NULL) {
+                                       n = NULL,
+                                       seed = NULL) {
   results <- list()
 
   # add site name if not included in df
@@ -184,9 +194,9 @@ calculate_spectral_metrics <- function(pixel_values_df,
   }
 
     # calculate metrics, pass rarefaction where needed
-    cv <- calculate_cv(site_pixel_values, wavelengths = wavelengths, rarefaction = rarefaction, n = n, min_points = min_points)
+    cv <- calculate_cv(site_pixel_values, wavelengths = wavelengths, rarefaction = rarefaction, n = n, min_points = min_points, seed = seed)
     sv <- calculate_sv(site_pixel_values, wavelengths = wavelengths)
-    chv <- calculate_chv_nopca(site_pixel_values, wavelengths, rarefaction = rarefaction, n = n, min_points = min_points)
+    chv <- calculate_chv_nopca(site_pixel_values, wavelengths, rarefaction = rarefaction, n = n, min_points = min_points, seed = seed)
 
     results[[site]] <- list(CV = cv, SV = sv, CHV = chv)
   }

--- a/man/calculate_cv.Rd
+++ b/man/calculate_cv.Rd
@@ -12,7 +12,8 @@ calculate_cv(
   wavelengths,
   rarefaction = FALSE,
   min_points = NULL,
-  n = NULL
+  n = NULL,
+  seed = NULL
 )
 }
 \arguments{
@@ -25,6 +26,10 @@ calculate_cv(
 \item{min_points}{Integer; minimum number of pixels per \code{aoi} to standardize uneven pixel numbers across sites (used if \code{rarefaction = TRUE}).}
 
 \item{n}{Integer; number of subset permutations if \code{rarefaction = TRUE}.}
+
+\item{seed}{Integer or NULL; if provided, \code{set.seed(seed)} is called once at the
+start of the function so the rarefaction sampling is reproducible. Default
+\code{NULL} preserves the prior unseeded behaviour.}
 }
 \value{
 A dataframe containing spectral metrics for each \code{aoi} within each site/raster.

--- a/tests/testthat/test-test_spectral.R
+++ b/tests/testthat/test-test_spectral.R
@@ -61,5 +61,23 @@ test_that('calculate_spectral_metrics works with rarefaction', {
   expect_true(all(metrics$site == 'site1'))
 })
 
+test_that('seed makes rarefaction reproducible', {
+  # df_test has 10 rows per aoi; sampling min_points = 5 forces a strict subset
+  # so RNG state matters (unlike min_points = 10 which would be degenerate).
+  args <- list(df_test, wavelengths = colnames(df_test[, 2:4]),
+               rarefaction = TRUE, min_points = 5, n = 20)
+
+  a <- do.call(calculate_spectral_metrics, c(args, list(seed = 42)))
+  b <- do.call(calculate_spectral_metrics, c(args, list(seed = 42)))
+  c <- do.call(calculate_spectral_metrics, c(args, list(seed = 7)))
+
+  # same seed -> identical CV and CHV (SV is unseeded — no sampling)
+  expect_equal(a$CV, b$CV)
+  expect_equal(a$CHV, b$CHV)
+  # different seed -> different rarefaction draws -> different CV / CHV
+  expect_false(isTRUE(all.equal(a$CV, c$CV)))
+  expect_false(isTRUE(all.equal(a$CHV, c$CHV)))
+})
+
 
 


### PR DESCRIPTION
## Summary
- Adds `seed = NULL` to `calculate_cv()`, `calculate_chv_nopca()`, and `calculate_spectral_metrics()`. When supplied, `set.seed(seed)` is called once at the start of each function so the `sample()` / `replicate(...)` calls inside rarefaction are reproducible.
- `calculate_spectral_metrics()` passes the seed through to `calculate_cv()` and `calculate_chv_nopca()`. `calculate_sv()` contains no sampling and is unchanged.
- Default `NULL` preserves the current unseeded behaviour — no existing tests change, no breaking change for downstream users.

## Why
Replicating the analysis in Gemmell et al. ("Applying the spectral variability hypothesis to arid shrublands") requires bit-exact reproducibility of CV and CHV across runs. We added the same pattern in our local `funx.R` and want to migrate to `saltbush::` without losing it.

## Test plan
- [x] `devtools::test()` — new test `seed makes rarefaction reproducible` passes locally
- [x] All other spectral tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)