### PR TITLE
Migrate extract_pixel_values to terra; drop raster dep; add aoi_id_col arg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,10 +15,9 @@ URL: https://github.com/traitecoevo/saltbush
 BugReports: https://github.com/traitecoevo/saltbush/issues
 Depends:
     R (>= 4.0.0)
-Imports: 
+Imports:
     dplyr,
     pROC,
-    raster,
     data.table,
     stringr,
     sf,
@@ -32,4 +31,4 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+Config/roxygen2/version: 7.3.3.9000

--- a/R/extract_pixel_values.R
+++ b/R/extract_pixel_values.R
@@ -5,6 +5,9 @@
 #' @param raster_files directory of input raster files
 #' @param aoi_files area of interest file - shapefile containing one or more site polygons for each raster
 #' @param wavelength_names the wavelength corresponding to each layer of the raster_files
+#' @param aoi_id_col Optional character; name of a column in the AOI shapefile
+#'   to use as the per-feature `aoi_id`. When `NULL` (default), the loop index
+#'   (`1:nrow(aois)`) is used, preserving the prior behaviour.
 #' @return a df with pixel values for each of the image layers
 #' @examples
 #' aoi_files <- list.files('inst/extdata/aoi',
@@ -14,7 +17,7 @@
 #' pixelvalues <- extract_pixel_values(raster_files, aoi_files, c('blue','green','red','red_edge','nir'))
 #' @export
 
-extract_pixel_values <- function(raster_files, aoi_files, wavelength_names){
+extract_pixel_values <- function(raster_files, aoi_files, wavelength_names, aoi_id_col = NULL){
 
   all_pixel_values_list <- list()
 
@@ -26,12 +29,20 @@ extract_pixel_values <- function(raster_files, aoi_files, wavelength_names){
     #choose the corresponding subplot file
     aoi_file <- aoi_files[grep(paste0('^', site_name), basename(aoi_files))]
 
-    # read in aoi file and select geometries
-    aois <- sf::read_sf(aoi_file) |>
-      dplyr::select('geometry')
+    # read in aoi file and select geometries (and the id column if requested)
+    aois <- sf::read_sf(aoi_file)
+    if (!is.null(aoi_id_col)) {
+      if (!aoi_id_col %in% names(aois)) {
+        stop(sprintf("aoi_id_col '%s' not found in %s", aoi_id_col, basename(aoi_file)))
+      }
+      aoi_ids <- aois[[aoi_id_col]]
+    } else {
+      aoi_ids <- seq_len(nrow(aois))
+    }
+    aois <- dplyr::select(aois, 'geometry')
 
     # read in raster file
-    raster_data <- raster::stack(raster_file)
+    raster_data <- terra::rast(raster_file)
 
     # apply consistent band names to each raster
     names(raster_data) <- wavelength_names
@@ -39,25 +50,23 @@ extract_pixel_values <- function(raster_files, aoi_files, wavelength_names){
     # create empty list
     pixel_values_list <- list()
 
-    for (i in 1:nrow(aois)){
+    for (i in seq_len(nrow(aois))){
 
       # select the i-th aoi and its id
       aoi <- aois[i, ]
+      aoi_id <- aoi_ids[i]
 
-      #aoi_id <- subplot$subplot_id
-      aoi_id <- i
+      # convert sf to SpatVector for mask() to work with rast()
+      aoi_vect <- terra::vect(aoi)
 
-      # convert to spatial object
-      aoi_sp <- as(aoi, "Spatial")
-
-      # crop and mask raster using current subplot
-      cropped_raster <- raster::crop(raster_data, aoi_sp)
-      masked_raster <- raster::mask(cropped_raster, aoi_sp)
+      # crop and mask raster using current aoi
+      cropped_raster <- terra::crop(raster_data, aoi_vect)
+      masked_raster <- terra::mask(cropped_raster, aoi_vect)
 
       # extract pixel values
-      pixel_values  <- as.data.frame(raster::getValues(masked_raster))
+      pixel_values <- as.data.frame(masked_raster)
 
-      # add subplot id to pixel values df
+      # add aoi id to pixel values df
       pixel_values$aoi_id <- aoi_id
 
       #add to list

--- a/man/extract_pixel_values.Rd
+++ b/man/extract_pixel_values.Rd
@@ -4,7 +4,12 @@
 \alias{extract_pixel_values}
 \title{Extract pixel values}
 \usage{
-extract_pixel_values(raster_files, aoi_files, wavelength_names)
+extract_pixel_values(
+  raster_files,
+  aoi_files,
+  wavelength_names,
+  aoi_id_col = NULL
+)
 }
 \arguments{
 \item{raster_files}{directory of input raster files}
@@ -12,6 +17,10 @@ extract_pixel_values(raster_files, aoi_files, wavelength_names)
 \item{aoi_files}{area of interest file - shapefile containing one or more site polygons for each raster}
 
 \item{wavelength_names}{the wavelength corresponding to each layer of the raster_files}
+
+\item{aoi_id_col}{Optional character; name of a column in the AOI shapefile
+to use as the per-feature \code{aoi_id}. When \code{NULL} (default), the loop index
+(\code{1:nrow(aois)}) is used, preserving the prior behaviour.}
 }
 \value{
 a df with pixel values for each of the image layers

--- a/tests/testthat/test-drone_process.R
+++ b/tests/testthat/test-drone_process.R
@@ -30,3 +30,34 @@ test_that("extract_pixel_values works", {
   expect_true(dim(pixelvalues)[1] > 2000000)
   expect_true(mean(pixelvalues[,3]) > 0.05 & mean(pixelvalues[,3]) < 0.06)
 })
+
+test_that("extract_pixel_values honours aoi_id_col", {
+  aoi_files <- list.files(
+    system.file("extdata/aoi", package = "saltbush"),
+    pattern = 'image_aoi.shp$', full.names = TRUE
+  )
+  raster_files <- list.files(
+    system.file("extdata/multiband_image", package = "saltbush"),
+    pattern = '.tif$', full.names = TRUE
+  )
+
+  # pick whichever non-geometry column the bundled AOI shapefile happens to expose
+  aoi_cols <- setdiff(names(sf::read_sf(aoi_files[1])), "geometry")
+  skip_if(length(aoi_cols) == 0, "bundled AOI shapefile has no attribute columns")
+  id_col <- aoi_cols[1]
+
+  pv <- extract_pixel_values(
+    raster_files, aoi_files, c('blue','green','red','red_edge','nir'),
+    aoi_id_col = id_col
+  )
+  expected_ids <- sf::read_sf(aoi_files[1])[[id_col]]
+  expect_true(all(unique(pv$aoi_id) %in% expected_ids))
+
+  # unknown column should error clearly
+  expect_error(
+    extract_pixel_values(raster_files, aoi_files,
+                         c('blue','green','red','red_edge','nir'),
+                         aoi_id_col = "definitely_not_a_column"),
+    "not found"
+  )
+})


### PR DESCRIPTION
## Summary
- Replaces the four remaining `raster::` calls in `R/extract_pixel_values.R` (`stack`, `crop`, `mask`, `getValues`) with their `terra::` equivalents. `as(aoi, "Spatial")` becomes `terra::vect(aoi)`.
- Drops `raster` from `DESCRIPTION` `Imports` — `extract_pixel_values` was the only function still using it. `terra` is already imported and used everywhere else in the package.
- Adds an optional `aoi_id_col` argument: when supplied, the per-feature `aoi_id` is read from that column of the AOI shapefile instead of the loop index. Default `NULL` preserves the prior behaviour, so existing callers are unaffected.

## Why
The `raster` package is on the deprecation track and `terra` is its modern replacement; the rest of `saltbush` already uses `terra`. This removes the last legacy `raster::` calls and lets us drop `raster` as a direct dependency. The `aoi_id_col` arg covers a use case where the shapefile carries meaningful feature ids (e.g. plot/subplot codes) and the caller wants those preserved end-to-end.

## Test plan
- [x] `devtools::test()` — existing `extract_pixel_values works` test still passes (the pixel-count threshold and mean-band-value assertions are unaffected by the terra migration)
- [x] New `extract_pixel_values honours aoi_id_col` test covers both the happy path and the unknown-column error

🤖 Generated with [Claude Code](https://claude.com/claude-code)